### PR TITLE
Stop using local cache

### DIFF
--- a/100k_tier_1_2_vars.py
+++ b/100k_tier_1_2_vars.py
@@ -14,14 +14,8 @@ optional arguments:
                         GeL participant ID for proband
 """
 
-from configparser import ConfigParser
-import os
 import sys
 import argparse
-import glob
-import re
-import json
-import datetime
 # Append JellyPy to python path, needed when running via paramiko from Windows
 sys.path.append('/home/mokaguys/Apps/JellyPy')
 from pyCIPAPI.interpretation_requests import get_interpretation_request_list, get_interpretation_request_json

--- a/100k_tier_1_2_vars.py
+++ b/100k_tier_1_2_vars.py
@@ -157,60 +157,11 @@ def zygosity_to_vcf(gel_zygosity):
     return vcf_lookup[gel_zygosity]
 
 
-def get_ir_json(ir_id, ir_version):
-    """
-    Get the interpretation request JSON for a case and return as a python json dictionary like object
-    For speed this function will use a local cached json rather than downloading a fresh copy, provided
-    the last_modified timestamp matches that found in the interpretation request list endpoint
-    Args:
-        ir_id: 100KGP interpretation request id without cip prefix or version suffix e.g. 12345 for case SAP-12345-1
-        ir_version: 100KGP interpretation request version e.g. 1 for case SAP-12345-1
-    Returns:
-        interpretation request as python dictionary-like json object
-    """
-    # Get list of local JSON file names (pulled using GeL2MDT)
-    local_jsons = ';'.join(glob.glob('{local_cache}/{ir_id}-{ir_version}-*.json'.format(
-            local_cache=config.get("GEL2MDT", "CIP-API-CACHE"),
-            ir_id=ir_id,
-            ir_version=ir_version
-        )
-    ))
-    # GeL2MDT appends sequential version numbers to the end of the JSON each time a new copy is downloaded
-    # Capture the GeL2MDT version number from end of each JSON file name to find latest file
-    versions = re.findall(r'{ir_id}-{ir_version}-(\d+).json'.format(ir_id=ir_id, ir_version=ir_version), local_jsons)
-    # If there's no local cache files, or filenames don't match expected format, versions will be an empty list so skip next block
-    if versions:
-        # Find highest version and construct filepath
-        max_version = max(list(map(int, versions)))
-        latest_cache_path = '{local_cache}/{ir_id}-{ir_version}-{max_version}.json'.format(
-                local_cache=config.get("GEL2MDT", "CIP-API-CACHE"),
-                ir_id=ir_id,
-                ir_version=ir_version,
-                max_version=max_version
-            )
-        # Read into a JSON object
-        with open(latest_cache_path, 'r') as cache_json:
-            ir_json = json.load(cache_json)
-        # Get overview of case from interpretation request list endpoint (this is much faster than pulling the full JSON)
-        ir_list = get_interpretation_request_list(interpretation_request_id=ir_id, version=ir_version)
-        # Check that this only returns one result
-        if len(ir_list) != 1:
-            sys.exit(f"Length of interpretation request list was {list_length} which is different to expected length 1".format(list_length=len(ir_list)))
-        # Get the last modified timestamp from cip api and local cache and convert to datetime objects
-        last_modified_api = datetime.datetime.strptime(ir_list[0]['last_modified'], "%Y-%m-%dT%H:%M:%S.%fZ")
-        last_modified_cache = datetime.datetime.strptime(ir_json['last_modified'], "%Y-%m-%dT%H:%M:%S.%fZ")
-        # Check if they match. If they do, return the local cache JSON.
-        if last_modified_api == last_modified_cache:
-            return ir_json
-    # If there is no local cache, or it's out of date, download a new JSON from CIP-API and return
-    return get_interpretation_request_json(ir_id, ir_version, reports_v6=True)
-
-
 def main():
     # Return arguments
     args = process_arguments()
     # Pull out interpretation request JSON
-    ir_json = get_ir_json(args.ir_id.split('-')[0], args.ir_id.split('-')[1])
+    ir_json = get_interpretation_request_json(args.ir_id.split('-')[0], args.ir_id.split('-')[1], reports_v6=True)
     # Capture the genome assembly
     assembly = ir_json['assembly']
     # Group variants by tier

--- a/100k_tier_1_2_vars.py
+++ b/100k_tier_1_2_vars.py
@@ -28,10 +28,6 @@ from pyCIPAPI.interpretation_requests import get_interpretation_request_list, ge
 # Import InterpretedGenome from GeLReportModels v6.0
 from protocols.reports_6_0_0 import InterpretedGenome
 
-config = ConfigParser()
-config.read(os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.ini"))
-
-
 def process_arguments():
     """
     Uses argparse module to define and handle command line input arguments and help menu

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# 100k_moka_variants v1.0
+# 100k_moka_variants v1.1
 ## 100k_tier_1_2_vars.py 
 
-This script pulls out all tier 1 and 2 variants from the CIP-API for a 100k case. For speed, the script will use a local cached copy of the JSON (as downloaded by GeL2MDT) when one is available and the `last_modified` timestamp matches that in the CIP-API interpretation request list endpoint.
+This script pulls out all tier 1 and 2 variants from the CIP-API for a 100k case.
 
 The variant details are printed to stdout in a tab separated format with the following columns:
 
@@ -23,7 +23,6 @@ Requirements:
 * JellyPy (in PYTHONPATH)
 * GelReportModels (v6 or higher)
 
-The path to the local cache of JSON files stored by GeL2MDT must be specified in a file named `config.ini` in the same directory of the script. See `example_config.ini` for format.
 
 On `SV-TE-GENAPP01` activate the `jellypy_py3` conda environment so that above requirements are met:
 

--- a/example_config.ini
+++ b/example_config.ini
@@ -1,6 +1,3 @@
 [MOKA]
 SERVER = <server_hostname>
 DATABASE = <database_name>
-
-[GEL2MDT]
-CIP-API-CACHE = <path_to_gel2mdt_cipapi_storage>


### PR DESCRIPTION
Going to stop using GeL2MDT so local cache won't get updated.
The download speed issue on the linux servers has now been fixed, so using a local cache is no longer necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/100k_moka_variants/5)
<!-- Reviewable:end -->
